### PR TITLE
Manage Traefik CRDs via ArgoCD

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,12 +87,6 @@ jobs:
           helm repo add traefik https://traefik.github.io/charts
           helm repo update
 
-      # Instalar Traefik-CRDs
-      - name: Instalar Traefik-CRDs
-        run: |
-          helm upgrade --install traefik-crds traefik/traefik-crds \
-            --namespace traefik --create-namespace \
-            --wait --timeout 2m
 
       # Diff de Traefik contra los valores de producción Netcup
       - name: Diff Traefik

--- a/README.md
+++ b/README.md
@@ -1,6 +1,29 @@
 # Albert Cluster
 
-Notas para gestionar el clúster personal.
+Repositorio GitOps para gestionar mi clúster personal con **Argo CD**.
+Toda la configuración de Kubernetes vive en este repositorio.
+
+## Puesta en marcha rápida
+
+Instala Argo CD y la aplicación raíz que sincronizará `infra/apps`:
+
+```bash
+kubectl apply -f infra/bootstrap/argocd.yaml
+kubectl apply -f infra/bootstrap/argocd-root.yaml
+```
+
+Tras ello Argo CD aplicará automáticamente los charts y manifiestos
+definidos en `infra/apps` (por ejemplo Traefik y sus CRDs).
+
+## Estructura del repositorio
+
+- `infra/bootstrap` contiene los manifiestos para instalar Argo CD y la
+  aplicación raíz que apunta a `infra/apps`.
+- `infra/apps` es la carpeta que Argo CD sincroniza; aquí se definen las
+  aplicaciones y charts del clúster.
+- `infra/envs` guarda valores específicos por entorno (p.ej. `minikube` y
+  `netcup`).
+- `docs` almacena la documentación de soporte.
 
 ## Acceso
 

--- a/docs/minikube-local.md
+++ b/docs/minikube-local.md
@@ -35,7 +35,20 @@ eval $(minikube docker-env)
 
 Sin esto, al hacer docker build tu imagen se queda en Docker Desktop y Kubernetes no la encuentra (tendrías que “push” a un registry externo).
 
-### 3. Construir y desplegar tu app
+### 3. Instalar Argo CD
+
+Aplica los manifiestos de `infra/bootstrap` para desplegar Argo CD y la
+aplicación raíz:
+
+```bash
+kubectl apply -f infra/bootstrap/argocd.yaml
+kubectl apply -f infra/bootstrap/argocd-root.yaml
+```
+
+Esto instalará Traefik y sus CRDs, entre otras aplicaciones definidas en
+`infra/apps`.
+
+### 4. Construir y desplegar tu app
 
 ```bash
 # 1. Construye la imagen DENTRO de Minikube

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,25 @@
+# Infraestructura Kubernetes
+
+Esta carpeta define todo lo necesario para desplegar el clúster mediante
+**Argo CD**.
+
+## Carpetas principales
+
+- `bootstrap/` contiene los manifiestos para instalar Argo CD (`argocd.yaml`)
+  y la aplicación raíz (`argocd-root.yaml`).
+- `apps/` incluye las aplicaciones gestionadas por Argo CD. Aquí se encuentran
+  los charts de Traefik y los CRDs, entre otros.
+- `envs/` alberga los valores específicos de cada entorno (por ejemplo
+  `minikube` para desarrollo local y `netcup` para producción).
+
+## Bootstrap
+
+Para iniciar un clúster desde cero:
+
+```bash
+kubectl apply -f infra/bootstrap/argocd.yaml
+kubectl apply -f infra/bootstrap/argocd-root.yaml
+```
+
+Después puedes acceder a la interfaz web de Argo CD o usar `argocd` CLI para
+sincronizar y revisar el estado de las aplicaciones.

--- a/infra/apps/traefik-crds.yaml
+++ b/infra/apps/traefik-crds.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: traefik-crds
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://traefik.github.io/charts
+    chart: traefik-crds
+    targetRevision: 22.1.0
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: traefik
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true


### PR DESCRIPTION
## Summary
- remove Traefik CRD install step from CI
- deploy Traefik CRDs via Argo CD
- improve README and docs to describe repository usage

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6864220c40f0832987e6c149ea882112