### PR TITLE
Add n8n application

### DIFF
--- a/infra/apps/n8n/n8n-deployment.yaml
+++ b/infra/apps/n8n/n8n-deployment.yaml
@@ -1,0 +1,21 @@
+# infra/apps/n8n/n8n-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: n8n
+  namespace: n8n
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: n8n
+  template:
+    metadata:
+      labels:
+        app: n8n
+    spec:
+      containers:
+      - name: n8n
+        image: n8nio/n8n
+        ports:
+        - containerPort: 5678

--- a/infra/apps/n8n/n8n-http-ingressroute.yaml
+++ b/infra/apps/n8n/n8n-http-ingressroute.yaml
@@ -1,0 +1,15 @@
+# infra/apps/n8n/n8n-http-ingressroute.yaml
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: n8n-http
+  namespace: n8n
+spec:
+  entryPoints:
+    - web
+  routes:
+    - match: Host(`auto.127.0.0.1.nip.io`)
+      kind: Rule
+      services:
+        - name: n8n
+          port: 80

--- a/infra/apps/n8n/n8n-ingressroute.yaml
+++ b/infra/apps/n8n/n8n-ingressroute.yaml
@@ -1,0 +1,18 @@
+# infra/apps/n8n/n8n-ingressroute.yaml
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: n8n
+  namespace: n8n
+spec:
+  entryPoints:
+    - web
+    - websecure
+  routes:
+    - match: Host(`auto.albertperez.dev`)
+      kind: Rule
+      services:
+        - name: n8n
+          port: 80
+  tls:
+    certResolver: le

--- a/infra/apps/n8n/n8n-namespace.yaml
+++ b/infra/apps/n8n/n8n-namespace.yaml
@@ -1,0 +1,5 @@
+# infra/apps/n8n/n8n-namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: n8n

--- a/infra/apps/n8n/n8n-service.yaml
+++ b/infra/apps/n8n/n8n-service.yaml
@@ -1,0 +1,12 @@
+# infra/apps/n8n/n8n-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: n8n
+  namespace: n8n
+spec:
+  ports:
+  - port: 80
+    targetPort: 5678
+  selector:
+    app: n8n


### PR DESCRIPTION
## Summary
- add namespace for n8n
- add n8n Deployment and Service
- expose n8n via IngressRoute
- include HTTP route for Minikube testing

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6864268b22b88329a9892216b4380761