### PR TITLE
Update docs for verifying Argo CD access

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,25 @@ kubectl apply -f infra/bootstrap/argocd-root.yaml
 helmfile -f infra/apps/helmfile.yaml apply
 ```
 
+### Step 3: Verify Argo CD Access
+
+Ensure that the Argo CD UI is reachable. If you expose Traefik via a
+`LoadBalancer` service, find the external IP and confirm your DNS record points
+to it:
+
+```bash
+kubectl get svc -n kube-system traefik
+```
+
+If Argo CD itself runs with a `LoadBalancer`, check its service instead:
+
+```bash
+kubectl get svc -n argocd argocd-server
+```
+
+Initial access requires either a `LoadBalancer` service or a working Traefik
+ingress so that the Argo CD endpoint is reachable through your firewall.
+
 For detailed installation instructions, see the [Installation Guide](docs/installation.md).
 
 ## 🔄 GitOps Architecture

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -30,6 +30,26 @@ Use Helmfile to manage the charts:
 helmfile -f infra/apps/helmfile.yaml apply
 ```
 
+### 3. Verify Argo CD Access
+
+Ensure that the Argo CD web UI is reachable before continuing. If your cluster
+exposes Traefik via a `LoadBalancer` service, check the external IP:
+
+```bash
+kubectl get svc -n kube-system traefik
+```
+
+Confirm that any DNS record for Argo CD points to this IP and that your
+firewall allows access. If Argo CD is installed with its own `LoadBalancer`
+service, verify it as well:
+
+```bash
+kubectl get svc -n argocd argocd-server
+```
+
+Initial login requires either a reachable `LoadBalancer` service or a working
+Traefik ingress.
+
 ## Environment Setup
 
 ### Local Development (Minikube)


### PR DESCRIPTION
## Summary
- document how to verify Argo CD is reachable via LoadBalancer or Traefik
- clarify that initial login needs a LoadBalancer or ingress

## Testing
- `npm test` *(fails: package.json not found and network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686a49afb9e48329b160644efeaedce5