### PR TITLE
Add cert-manager setup with wildcard certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Helmfile (render) → YAML plano → ArgoCD (deploy)
 │   │   ├── hello/
 │   │   │   ├── helmfile.yaml
 │   │   │   └── values.yaml
+│   │   ├── cert-manager/
+│   │   │   ├── helmfile.yaml
+│   │   │   └── values.yaml
 │   │   └── traefik/
 │   │       ├── helmfile.yaml
 │   │       └── values.yaml

--- a/infra/apps/cert-manager/helmfile.yaml
+++ b/infra/apps/cert-manager/helmfile.yaml
@@ -1,0 +1,21 @@
+environments:
+  minikube: {}
+  netcup: {}
+
+---
+repositories:
+  - name: jetstack
+    url: https://charts.jetstack.io
+
+releases:
+  - name: cert-manager
+    namespace: cert-manager
+    createNamespace: true
+    chart: jetstack/cert-manager
+    version: v1.18.2
+    values:
+      - values.yaml
+      - ../../envs/{{ .Environment.Name }}/cert-manager-values.yaml
+    wait: true
+    timeout: 300
+    atomic: true

--- a/infra/apps/cert-manager/values.yaml
+++ b/infra/apps/cert-manager/values.yaml
@@ -1,0 +1,4 @@
+# infra/apps/cert-manager/values.yaml
+# Valores base para cert-manager
+
+installCRDs: false

--- a/infra/bootstrap/kustomization.yaml
+++ b/infra/bootstrap/kustomization.yaml
@@ -2,7 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - crds/traefik-crds.yaml
-  - rbac/gh-actions.yaml        
+  - crds/cert-manager-CRDs.yaml
+  - rbac/gh-actions.yaml
   - argocd.yaml
   - argocd-root.yaml
   - argocd-minikube.yaml

--- a/infra/envs/minikube/cert-manager-values.yaml
+++ b/infra/envs/minikube/cert-manager-values.yaml
@@ -1,0 +1,48 @@
+# infra/envs/minikube/cert-manager-values.yaml
+# Overrides específicos para cert-manager en Minikube
+
+extraObjects:
+  # ClusterIssuer que genera un CA auto firmado
+  - apiVersion: cert-manager.io/v1
+    kind: ClusterIssuer
+    metadata:
+      name: selfsigned
+    spec:
+      selfSigned: {}
+
+  # Certificado CA usando el issuer selfsigned
+  - apiVersion: cert-manager.io/v1
+    kind: Certificate
+    metadata:
+      name: local-ca
+      namespace: cert-manager
+    spec:
+      isCA: true
+      commonName: local-ca
+      secretName: local-ca
+      issuerRef:
+        name: selfsigned
+        kind: ClusterIssuer
+
+  # ClusterIssuer que usa el CA generado previamente
+  - apiVersion: cert-manager.io/v1
+    kind: ClusterIssuer
+    metadata:
+      name: local-ca-issuer
+    spec:
+      ca:
+        secretName: local-ca
+
+  # Certificado wildcard para el entorno local
+  - apiVersion: cert-manager.io/v1
+    kind: Certificate
+    metadata:
+      name: wildcard-minikube
+      namespace: traefik
+    spec:
+      secretName: wildcard-minikube-tls
+      dnsNames:
+        - '*.127.0.0.1.nip.io'
+      issuerRef:
+        name: local-ca-issuer
+        kind: ClusterIssuer

--- a/infra/envs/netcup/cert-manager-values.yaml
+++ b/infra/envs/netcup/cert-manager-values.yaml
@@ -1,0 +1,36 @@
+# infra/envs/netcup/cert-manager-values.yaml
+# Overrides específicos para cert-manager en producción
+
+extraObjects:
+  # ClusterIssuer Let's Encrypt usando Cloudflare DNS
+  - apiVersion: cert-manager.io/v1
+    kind: ClusterIssuer
+    metadata:
+      name: letsencrypt-prod
+    spec:
+      acme:
+        email: {{ .Environment.Values.certmanager.email }}
+        server: https://acme-v02.api.letsencrypt.org/directory
+        privateKeySecretRef:
+          name: letsencrypt-prod
+        solvers:
+          - dns01:
+              cloudflare:
+                email: {{ .Environment.Values.certmanager.email }}
+                apiTokenSecretRef:
+                  name: cloudflare-api-token
+                  key: api-token
+
+  # Certificado wildcard para el dominio principal
+  - apiVersion: cert-manager.io/v1
+    kind: Certificate
+    metadata:
+      name: wildcard-netcup
+      namespace: traefik
+    spec:
+      secretName: wildcard-netcup-tls
+      dnsNames:
+        - '*.albertperez.dev'
+      issuerRef:
+        name: letsencrypt-prod
+        kind: ClusterIssuer


### PR DESCRIPTION
## Summary
- enable cert-manager CRDs in bootstrap kustomization
- create cert-manager helmfile and base values
- configure wildcard certificates for minikube and netcup
- include cert-manager paths in README

## Testing
- `pip install pyyaml` *(failed: Tunnel connection failed)*


------
https://chatgpt.com/codex/tasks/task_e_686eb788b3e483299906fc919beb3374