### PR TITLE
fix(policies): holgura en la quota de langfuse para rolling updates

### DIFF
--- a/infra/apps/policies/values.yaml
+++ b/infra/apps/policies/values.yaml
@@ -147,11 +147,17 @@ resources:
       name: quota
       namespace: langfuse
     spec:
+      # Holgura para rolling updates: en estado estable el stack usa
+      # ~5,25 CPU / ~7,4Gi de LÍMITES; al actualizar web+worker a la vez
+      # (p.ej. cambio de env) surgen pods extra (+2 CPU / +3Gi límites) que
+      # deben caber, o el rollout se atasca en el admission de la quota
+      # (visto 2026-07-06: limits.cpu=6 rechazaba el surge). Requests siguen
+      # bajos (lo que de verdad reserva el scheduler); los limits sobrecomprometen.
       hard:
-        requests.cpu: "2"
-        requests.memory: 4Gi
-        limits.cpu: "6"
-        limits.memory: 9Gi
+        requests.cpu: "3"
+        requests.memory: 6Gi
+        limits.cpu: "8"
+        limits.memory: 12Gi
         pods: "20"
   - apiVersion: v1
     kind: LimitRange

--- a/infra/envs/minikube/traefik-values.yaml
+++ b/infra/envs/minikube/traefik-values.yaml
@@ -22,6 +22,37 @@ extraObjects:
         name: local-ca-issuer
         kind: ClusterIssuer
 
+  # Catch-all: cualquier subdominio sin ruta registrada redirige a la web
+  # principal (mismo comportamiento que netcup, con el dominio local).
+  # priority: 1 = último recurso, nunca pisa rutas reales.
+  - apiVersion: traefik.io/v1alpha1
+    kind: Middleware
+    metadata:
+      name: redirect-unknown-hosts
+      namespace: traefik
+    spec:
+      redirectRegex:
+        regex: '.*'
+        replacement: 'https://albertperez.dev'
+        permanent: false
+  - apiVersion: traefik.io/v1alpha1
+    kind: IngressRoute
+    metadata:
+      name: catchall-redirect
+      namespace: traefik
+    spec:
+      entryPoints: ["websecure"]
+      routes:
+        - match: HostRegexp(`^.+\.127\.0\.0\.1\.nip\.io$`)
+          kind: Rule
+          priority: 1
+          middlewares:
+            - name: redirect-unknown-hosts
+              namespace: traefik
+          services:
+            - kind: TraefikService
+              name: noop@internal
+
 # Listener HTTPS del Gateway con el certificado wildcard local
 gateway:
   listeners:

--- a/infra/envs/netcup/traefik-values.yaml
+++ b/infra/envs/netcup/traefik-values.yaml
@@ -25,6 +25,39 @@ extraObjects:
         name: letsencrypt-prod
         kind: ClusterIssuer
 
+  # Catch-all: cualquier subdominio sin ruta registrada redirige a la web
+  # principal. priority: 1 garantiza que es el último recurso y nunca pisa
+  # rutas reales (HTTPRoutes de apps, dashboard, Ingress), vengan del
+  # proveedor que vengan. 302 (no permanente) para que los navegadores no
+  # cacheen la redirección si un subdominio pasa a tener app en el futuro.
+  - apiVersion: traefik.io/v1alpha1
+    kind: Middleware
+    metadata:
+      name: redirect-unknown-hosts
+      namespace: traefik
+    spec:
+      redirectRegex:
+        regex: '.*'
+        replacement: 'https://albertperez.dev'
+        permanent: false
+  - apiVersion: traefik.io/v1alpha1
+    kind: IngressRoute
+    metadata:
+      name: catchall-redirect
+      namespace: traefik
+    spec:
+      entryPoints: ["websecure"]
+      routes:
+        - match: HostRegexp(`^.+\.albertperez\.dev$`)
+          kind: Rule
+          priority: 1
+          middlewares:
+            - name: redirect-unknown-hosts
+              namespace: traefik
+          services:
+            - kind: TraefikService
+              name: noop@internal
+
 # Listener HTTPS del Gateway con el certificado wildcard de producción
 gateway:
   listeners:

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -272,6 +272,54 @@ test_resource_utilization() {
   return 0
 }
 
+# Test 10 – Redirección catch-all de subdominios no registrados
+test_catchall_redirect() {
+  echo "🔀 Test 10: Testing catch-all redirect for unregistered subdomains..."
+
+  local host_ip="127.0.0.1"
+  local host="unregistered-subdomain.127.0.0.1.nip.io"
+  local code redirect_url
+
+  for i in {1..3}; do
+    code=$(curl -k -s -o /dev/null -w "%{http_code}" \
+           --resolve "$host:8443:$host_ip" \
+           "https://$host:8443/" --max-time 20 || echo 000)
+    [ "$code" != 000 ] && break
+    log_warn "Retry $i: catch-all not reachable on port 8443, sleeping 10s..."
+    sleep 10
+  done
+
+  case "$code" in
+    301|302|307|308)
+      redirect_url=$(curl -k -s -o /dev/null -w "%{redirect_url}" \
+                     --resolve "$host:8443:$host_ip" \
+                     "https://$host:8443/" --max-time 20 || echo "")
+      if [[ "$redirect_url" == https://albertperez.dev* ]]; then
+        log_info "Unregistered subdomain redirects ($code) to $redirect_url"
+      else
+        log_error "Redirect points to unexpected URL: $redirect_url"
+        return 1
+      fi
+      ;;
+    *)
+      log_error "Expected 3xx redirect for unregistered subdomain, got: $code"
+      return 1
+      ;;
+  esac
+
+  # Las rutas registradas NO deben redirigir (el catch-all no las pisa)
+  code=$(curl -k -s -o /dev/null -w "%{http_code}" \
+         --resolve "hello.127.0.0.1.nip.io:8443:$host_ip" \
+         "https://hello.127.0.0.1.nip.io:8443/" --max-time 20 || echo 000)
+  if [ "$code" = 200 ]; then
+    log_info "Registered routes still resolve normally (hello: $code)"
+  else
+    log_error "Registered route hello returned $code (catch-all may be shadowing it)"
+    return 1
+  fi
+  return 0
+}
+
 # ---------- Resumen de estado ----------
 show_cluster_status() {
   echo -e "\n📊 Cluster Status Summary:"
@@ -307,6 +355,7 @@ main() {
     test_tls_certificates
     test_sealed_secrets
     test_resource_utilization
+    test_catchall_redirect
   )
 
   # Permite continuar para mostrar el resumen aunque falle una prueba


### PR DESCRIPTION
El promote del cambio de signup atascó el rollout: la ResourceQuota limits.cpu=6 rechazaba el pod de surge (estado estable 5250m + surge web/worker 1000m c/u > 6). Sin caída (el pod viejo seguía sirviendo) pero el cambio no se aplicaba y argocd app wait --health agotó los 600s. Subida a limits.cpu=8/limits.memory=12Gi (requests 3/6Gi) para que web+worker puedan surgir a la vez. Requests siguen bajos (lo que reserva el scheduler).