### PR TITLE
feat(gotenberg): API HTML/Office→PDF en gotenberg.albertperez.dev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,3 +43,9 @@ LANGFUSE_POSTGRES_PASSWORD=
 LANGFUSE_CLICKHOUSE_PASSWORD=
 LANGFUSE_REDIS_PASSWORD=
 LANGFUSE_S3_ROOT_PASSWORD=
+
+# --- gotenberg: basic auth de la API (gotenberg.albertperez.dev) ---
+# Opcionales: vacías se generan aleatorias al sellar (la contraseña se imprime
+# al generar; guárdala, no se puede recuperar del SealedSecret).
+GOTENBERG_USER=gotenberg
+GOTENBERG_PASSWORD=

--- a/.github/workflows/dev-ci.yaml
+++ b/.github/workflows/dev-ci.yaml
@@ -222,6 +222,9 @@ jobs:
         run: |
           source versions.env
           minikube ssh "docker pull traefik:${TRAEFIK_IMAGE_VERSION}; docker pull quay.io/jetstack/cert-manager-controller:${CERT_MANAGER_IMAGE_VERSION}"
+          # Gotenberg: imagen única de ~1GB (Chromium+LibreOffice); sin pre-pull
+          # el --wait de 300s no llega (visto 2026-08-20)
+          minikube ssh "docker pull gotenberg/gotenberg:${GOTENBERG_IMAGE_VERSION}" > /dev/null 2>&1 &
 
           # Langfuse: ~5GB en 6 imágenes. El kubelet las baja EN SERIE dentro
           # del --wait de helm → context deadline exceeded (visto 2026-07-06).

--- a/.github/workflows/dev-ci.yaml
+++ b/.github/workflows/dev-ci.yaml
@@ -267,6 +267,20 @@ jobs:
           }
           echo "✅ Certificate wildcard-minikube-tls ready"
 
+      - name: Debug Gotenberg if deployment fails
+        if: failure()
+        run: |
+          kubectl get pods -n gotenberg -o wide || true
+          kubectl get events -n gotenberg --sort-by=.lastTimestamp | tail -30 || true
+          kubectl describe pods -n gotenberg | grep -B2 -A20 "Events:" || true
+          kubectl describe node | sed -n '/Allocated resources/,/Events/p' || true
+          echo "::group::logs gotenberg (current)"
+          kubectl logs -n gotenberg -l app.kubernetes.io/name=gotenberg --tail=120 || true
+          echo "::endgroup::"
+          echo "::group::logs gotenberg (previous crash)"
+          kubectl logs -n gotenberg -l app.kubernetes.io/name=gotenberg --previous --tail=120 || true
+          echo "::endgroup::"
+
       - name: Debug Langfuse if deployment fails
         if: failure()
         run: |

--- a/.github/workflows/dev-ci.yaml
+++ b/.github/workflows/dev-ci.yaml
@@ -151,6 +151,14 @@ jobs:
           SECRETS_DIR="$LANGFUSE_SECRETS_DIR" ../../scripts/generate-credentials.sh --component langfuse
           kubectl apply -f "$LANGFUSE_SECRETS_DIR/langfuse-secrets-sealed.yaml"
 
+          # Gotenberg: basic auth de la API (usuario/contraseña fijos en CI para
+          # que el smoke test se autentique); dir temporal para no pisar el
+          # sellado de prod del repo
+          GOTENBERG_SECRETS_DIR=$(mktemp -d)
+          SECRETS_DIR="$GOTENBERG_SECRETS_DIR" GOTENBERG_USER=ci GOTENBERG_PASSWORD=ci-gotenberg \
+            ../../scripts/generate-credentials.sh --component gotenberg
+          kubectl apply -f "$GOTENBERG_SECRETS_DIR/gotenberg-basic-auth-sealed.yaml"
+
           echo "::group::Generate Cloudflare dummy secret"
           cat <<EOF | kubeseal --controller-name=sealed-secrets --controller-namespace=kube-system --format yaml > secrets/cloudflare-api-token-sealed.yaml
           apiVersion: v1
@@ -297,6 +305,15 @@ jobs:
           kubectl wait deployment -n hello --all --for=condition=Available --timeout=300s
           echo "::endgroup::"
 
+          echo "::group::Wait for Gotenberg"
+          kubectl wait deployment -n gotenberg --all --for=condition=Available --timeout=300s || {
+            kubectl get pods -n gotenberg -o wide
+            kubectl describe pods -n gotenberg | grep -A15 "Events:"
+            kubectl logs -n gotenberg -l app.kubernetes.io/name=gotenberg --tail=100 || true
+            exit 1
+          }
+          echo "::endgroup::"
+
           echo "::group::Wait for Prometheus Stack"
           kubectl wait deployment -n monitoring --all --for=condition=Available --timeout=300s
           echo "::endgroup::"
@@ -317,7 +334,7 @@ jobs:
       - name: Enhanced smoke tests
         run: |
           chmod +x tests/smoke.sh
-          WAIT_TIMEOUT=300s ./tests/smoke.sh
+          WAIT_TIMEOUT=300s GOTENBERG_USER=ci GOTENBERG_PASSWORD=ci-gotenberg ./tests/smoke.sh
 
       - name: Cleanup Minikube
         if: always()

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -56,6 +56,7 @@ ignore: |
   infra/rendered/
   infra/bootstrap/crds/
   infra/charts/hello/templates/
+  infra/charts/gotenberg/templates/
   infra/bootstrap/secrets/
   infra/bootstrap/rbac/
   .github/workflows/

--- a/deploy-local.sh
+++ b/deploy-local.sh
@@ -77,6 +77,7 @@ wait_for_sealed_secrets() {
         "admin-basic-auth:admin"
         "cloudflare-api-token:cert-manager"
         "grafana-admin:monitoring"
+        "gotenberg-basic-auth:gotenberg"
     )
 
     for item in "${sealed_secrets[@]}"; do
@@ -162,6 +163,11 @@ apply_bootstrap() {
         bash "${SCRIPT_DIR}/scripts/generate-credentials.sh" --component langfuse
     kubectl apply -f "${LOCAL_SECRETS_DIR}/langfuse-secrets-sealed.yaml"
 
+    # Basic auth de la API de Gotenberg (aleatoria en local; se imprime al generar)
+    SECRETS_DIR="$LOCAL_SECRETS_DIR" \
+        bash "${SCRIPT_DIR}/scripts/generate-credentials.sh" --component gotenberg
+    kubectl apply -f "${LOCAL_SECRETS_DIR}/gotenberg-basic-auth-sealed.yaml"
+
     # Generate cloudflare-api-token with dummy for local
     echo "Generating dummy Cloudflare API token secret for local..."
     TMP_SECRET_YAML=$(mktemp)
@@ -233,6 +239,8 @@ deploy_applications() {
     export HELLO_CHART_VERSION
     export ARGOCD_CHART_VERSION
     export PROMETHEUS_CHART_VERSION
+    export GOTENBERG_CHART_VERSION
+    export GOTENBERG_IMAGE_VERSION
 
     # Apply applications idempotently (excluding SealedSecrets as it's already installed in bootstrap)
     helmfile --environment minikube apply --suppress-secrets --selector 'name!=sealed-secrets'

--- a/docs/apps.md
+++ b/docs/apps.md
@@ -15,6 +15,7 @@ en `infra/envs/<entorno>/<app>-values.yaml`. Versiones en
 | velero | `vmware-tanzu/velero` | `12.1.0` | `velero` | Backups a R2 (solo netcup) | [velero.io](https://velero.io/docs/) |
 | policies | `bedag/raw` | `2.0.2` | (multi) | NetworkPolicy/quotas por ns de app | [github](https://github.com/bedag/helm-charts/tree/master/charts/raw) |
 | hello | local `infra/charts/hello` | `0.3.0` | `hello` | App de ejemplo/plantilla/canario | — |
+| gotenberg | local `infra/charts/gotenberg` | `0.1.0` (imagen `8.36.0`) | `gotenberg` | API HTML/Office → PDF (`gotenberg.albertperez.dev`) | [gotenberg.dev](https://gotenberg.dev/docs/getting-started/introduction) |
 
 Repos de charts:
 [traefik](https://traefik.github.io/charts) ·
@@ -134,3 +135,34 @@ dejarla como health-check trivial o quitarla cuando tengas apps reales (mismo
 método que prometheus opción B). El chart en `infra/charts/hello` es la
 referencia de cómo se ve una app bien hecha (securityContext, HTTPRoute,
 recursos). Ver [adding-apps.md](adding-apps.md).
+
+## gotenberg
+
+API HTTP stateless para generar PDFs (HTML/Markdown/URL vía Chromium, Office
+vía LibreOffice). Chart local `infra/charts/gotenberg` (imagen oficial
+`gotenberg/gotenberg`, tag pineado en `GOTENBERG_IMAGE_VERSION`). Expuesto en
+`gotenberg.albertperez.dev` por `HTTPRoute`.
+
+Seguridad (la API sin auth permite a cualquiera renderizar URLs **desde dentro
+del cluster**):
+
+- **Basic auth nativo** (`--api-enable-basic-auth`): credenciales en el Secret
+  `gotenberg-basic-auth` (SealedSecret, `generate-credentials.sh --component
+  gotenberg`; `GOTENBERG_USER`/`GOTENBERG_PASSWORD` en `.env` o aleatorias).
+  `/health` queda sin auth para las probes.
+- **Deny-list de Chromium** anti-SSRF: loopback, rangos privados, link-local
+  (metadata) y `*.svc`/`*.cluster.local`.
+- Pod `restricted`: uid 1001, rootfs RO (solo `/tmp` en emptyDir con
+  `sizeLimit`), sin SA token, sin capabilities.
+- `--api-timeout=60s` y límites 1 CPU / 1.5Gi (Chromium+LibreOffice).
+
+Uso:
+
+```bash
+curl -u "$GOTENBERG_USER:$GOTENBERG_PASSWORD" \
+  -F files=@index.html \
+  https://gotenberg.albertperez.dev/forms/chromium/convert/html -o out.pdf
+```
+
+En netcup gateado por `GOTENBERG_ENABLED` (versions.env) hasta que el
+SealedSecret esté sellado contra prod (mismo patrón que langfuse).

--- a/infra/apps/gotenberg/app.yaml
+++ b/infra/apps/gotenberg/app.yaml
@@ -1,0 +1,5 @@
+# Descubierto por el ApplicationSet (git files generator).
+# Crear este fichero = la app aparece en ArgoCD; borrarlo = se poda.
+name: gotenberg
+namespace: gotenberg   # destination.namespace de la Application
+wave: "3"       # documental: orden de bootstrap / helmfile raíz

--- a/infra/apps/gotenberg/helmfile.yaml.gotmpl
+++ b/infra/apps/gotenberg/helmfile.yaml.gotmpl
@@ -21,4 +21,5 @@ releases:
     wait: true
     # Imagen de ~1GB: en CI el pull puede comerse casi todo el --wait
     timeout: 600
-    atomic: true
+    # Sin atomic a propósito: si el --wait falla en CI, el paso de debug de
+    # dev-ci necesita el pod vivo para ver eventos/logs (atomic lo desinstala).

--- a/infra/apps/gotenberg/helmfile.yaml.gotmpl
+++ b/infra/apps/gotenberg/helmfile.yaml.gotmpl
@@ -1,0 +1,23 @@
+environments:
+  minikube: {}
+  netcup: {}
+
+---
+releases:
+  - name: gotenberg
+    namespace: gotenberg
+    createNamespace: true
+    chart: ../../charts/gotenberg
+    version: {{ env "GOTENBERG_CHART_VERSION" }}
+    # En minikube/CI siempre (secreto generado al vuelo); en netcup solo
+    # cuando gotenberg-basic-auth esté sellado contra prod y
+    # GOTENBERG_ENABLED=true (versions.env) — mismo patrón que langfuse.
+    installed: {{ or (ne .Environment.Name "netcup") (eq (env "GOTENBERG_ENABLED" | default "false") "true") }}
+    values:
+      - values.yaml
+      - ../../envs/{{ .Environment.Name }}/gotenberg-values.yaml
+      - image:
+          tag: {{ requiredEnv "GOTENBERG_IMAGE_VERSION" | quote }}
+    wait: true
+    timeout: 300
+    atomic: true

--- a/infra/apps/gotenberg/helmfile.yaml.gotmpl
+++ b/infra/apps/gotenberg/helmfile.yaml.gotmpl
@@ -19,5 +19,6 @@ releases:
       - image:
           tag: {{ requiredEnv "GOTENBERG_IMAGE_VERSION" | quote }}
     wait: true
-    timeout: 300
+    # Imagen de ~1GB: en CI el pull puede comerse casi todo el --wait
+    timeout: 600
     atomic: true

--- a/infra/apps/gotenberg/values.yaml
+++ b/infra/apps/gotenberg/values.yaml
@@ -1,0 +1,18 @@
+# infra/apps/gotenberg/values.yaml
+# Valores base de Gotenberg (chart local infra/charts/gotenberg; el tag de la
+# imagen llega por helmfile desde GOTENBERG_IMAGE_VERSION en versions.env).
+#
+# Auth: basic auth nativo de Gotenberg con el Secret `gotenberg-basic-auth`
+# (SealedSecret; se genera con scripts/generate-credentials.sh --component
+# gotenberg). Los clientes envían Authorization: Basic user:pass.
+# /health queda sin auth (probes); el resto de rutas lo exigen.
+#
+# Hostname por entorno en infra/envs/<entorno>/gotenberg-values.yaml.
+
+replicaCount: 1
+
+gotenberg:
+  apiTimeout: 60s
+  basicAuth:
+    enabled: true
+    existingSecret: gotenberg-basic-auth

--- a/infra/apps/helmfile.yaml
+++ b/infra/apps/helmfile.yaml
@@ -30,3 +30,4 @@ helmfiles:
   - path: ./velero/helmfile.yaml.gotmpl         # wave 3 (solo netcup)
   - path: ./policies/helmfile.yaml.gotmpl       # wave 3
   - path: ./langfuse/helmfile.yaml.gotmpl       # wave 3 (netcup: gateado por LANGFUSE_ENABLED)
+  - path: ./gotenberg/helmfile.yaml.gotmpl     # wave 3 (netcup: gateado por GOTENBERG_ENABLED)

--- a/infra/apps/policies/values.yaml
+++ b/infra/apps/policies/values.yaml
@@ -174,3 +174,66 @@ resources:
           defaultRequest:
             cpu: 50m
             memory: 128Mi
+
+  # ---------------- gotenberg ----------------
+  # Un solo Deployment (200m/512Mi req, 1 CPU/1.5Gi lim) + surge en rollouts.
+  - apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      name: default-deny-ingress
+      namespace: gotenberg
+    spec:
+      podSelector: {}
+      policyTypes: [Ingress]
+  - apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      name: allow-from-traefik
+      namespace: gotenberg
+    spec:
+      podSelector: {}
+      policyTypes: [Ingress]
+      ingress:
+        - from:
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: traefik
+  - apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      name: allow-from-monitoring
+      namespace: gotenberg
+    spec:
+      podSelector: {}
+      policyTypes: [Ingress]
+      ingress:
+        - from:
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: monitoring
+  - apiVersion: v1
+    kind: ResourceQuota
+    metadata:
+      name: quota
+      namespace: gotenberg
+    spec:
+      hard:
+        requests.cpu: "1"
+        requests.memory: 1536Mi
+        limits.cpu: "3"
+        limits.memory: 4Gi
+        pods: "5"
+  - apiVersion: v1
+    kind: LimitRange
+    metadata:
+      name: defaults
+      namespace: gotenberg
+    spec:
+      limits:
+        - type: Container
+          default:
+            cpu: 500m
+            memory: 512Mi
+          defaultRequest:
+            cpu: 50m
+            memory: 128Mi

--- a/infra/bootstrap/namespaces/gotenberg.yaml
+++ b/infra/bootstrap/namespaces/gotenberg.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gotenberg
+  labels:
+    argocd.argoproj.io/managed-by: argocd
+    # PSS (chart local endurecido: non-root 1001, rootfs RO, sin capabilities)
+    pod-security.kubernetes.io/enforce: restricted
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"

--- a/infra/bootstrap/namespaces/kustomization.yaml
+++ b/infra/bootstrap/namespaces/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - velero.yaml
   - openebs.yaml
   - langfuse.yaml
+  - gotenberg.yaml

--- a/infra/bootstrap/secrets/gotenberg-basic-auth-sealed.yaml
+++ b/infra/bootstrap/secrets/gotenberg-basic-auth-sealed.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: gotenberg-basic-auth
+  namespace: gotenberg
+spec:
+  encryptedData:
+    password: AgCVDj9VQhb359YHdjt3ayJ9m3m3gEUPmgIlHJfTKYeCyun3P7JXyFYsW/VciU6B3heyebvcyGrVyfw9ZSknfVGvROujhx9bx6b+p7iw0B/ullCJogUfcMewBk77EC4dHe2kh0gPzo2wdyUteh2H27ORJQnnTwfM8cuW2jKiH1x+yjnKf8cC9GsPKXPtt8Bq8c/a/R3LIhwS4KEub+Tv103lvcSDi0hrGD2bnWUeu1w/OXqy1EtpCDGk3d/SsSIizb3Kr1OYXEoNZwKUagEZ7CyXk7Albu+JTuXBJ6XrJ26Cn96iVIZ8Md4SYfEkuryppuoVvVOFo634jbB+O3HgUs8q2C9BelXko6bQnquEj9IAMVOmVCSB0CKF3JPfMOxLeaZhoLVF1fKq/2YfCqdIXIx2w1gnF6pKwlDBLUjhCLjU/D0bD4XD6lji7cL64WEwwjTfr8Qzgn0DlAD8/BAeJgP0OmJ485fJCTtOP/PSYdoayC3GJ0Yr/5gOEIyKSlbsvpgoc2/Hz7W2uqbdc/keB4YHeFOkb2MifO38wKrsc+Udzx0Zm5qb+LPJNkpDPrpd5tyZ/p8QdxpXyNExxWfsILp6FPeRwtEmFys5Thwb7GnkWnPY40lXOEtWjiShaspT21trgagK0NsNWprY7DPut0PJZIr3owaoBpY90dcTloDnHhibLg/q0JbILkCJyTWzufhz8a+hSOhPnnmgURvgOalGz599NB6Y5vyPKVaX4jRx/y1obEwiT1uKpCgexuTases=
+    username: AgCq8yNIvcwEfVuweJhsFvAsrISfSOPBhd0n+x1gfpYFdWg9kQJMHC2yHUNWJMZ08xKCh4SWCf4VNt23e2GWaaEFKqMrZ2NrnMmbUQXf4t2ALaeK78rat7BDCGa2AZeB29sIJQ1I4qmpOPPD+vtARsTMLpG+M8ibT1xJCGV8a/oDB4EptABoi7WQvCc1CH1O3jAsFXwKl9eHbMIKQpL3FvmALy/35WDTQbtIECZlOnGU0WcoTE8okAR27KXTcyr0lY4vMB8Pm34whQ3P/kM6u/JfpJJbkZAR911DCzTcWQ/k8wnhebDSmDA3oh3l5Ug91c1Ux6Jcm94ooQMeZyGjEBPbQDZ3BObUSiAifTanMtlG+gY4+tTJRfCMBDndsrInAw7zDPzhA/LGjSPPdD3xZYUTxIGa/DLhn7Qp8zMpv1bwR2rH+W+YMjrNbYI48ETHN+qzaNz9sTsm+yP2yGcIUsPM4arEHO5wxlXHgzCHsVi5i+Mm1OBx+fZn8MKB/Udaq3ExzhPRyvY93imaRiLmR8BgBU6Nmn/NYeywMzJCRUgyDfzHAgrCtHN2By0rgiX2jYZNa2HVfrMA5ICGMoXILP5QWDS2BICviqIGtrvmB6LntP+a1vZVACN5rZP4XFDeBS3o4VPARswpDRtT5EYBGgCAd/O2s8ncqS+uIAuZkx6h9TckRWY7iMghYkhKHApFuAcwsB4kFRWHIo8=
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/component: gotenberg
+        app.kubernetes.io/managed-by: kubeseal
+      name: gotenberg-basic-auth
+      namespace: gotenberg
+    type: Opaque

--- a/infra/charts/gotenberg/Chart.yaml
+++ b/infra/charts/gotenberg/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: gotenberg
+description: Gotenberg — API HTTP para convertir HTML/Markdown/Office a PDF (Chromium + LibreOffice)
+type: application
+version: 0.1.0
+# Informativo: la imagen real se pinea por values (image.tag ← GOTENBERG_IMAGE_VERSION)
+appVersion: "8.36.0"

--- a/infra/charts/gotenberg/templates/_helpers.tpl
+++ b/infra/charts/gotenberg/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "gotenberg.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "gotenberg.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "gotenberg.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "gotenberg.labels" -}}
+helm.sh/chart: {{ include "gotenberg.chart" . }}
+{{ include "gotenberg.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "gotenberg.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "gotenberg.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/infra/charts/gotenberg/templates/deployment.yaml
+++ b/infra/charts/gotenberg/templates/deployment.yaml
@@ -1,0 +1,117 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "gotenberg.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gotenberg.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "gotenberg.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "gotenberg.selectorLabels" . | nindent 8 }}
+      {{- if .Values.metrics.enabled }}
+      annotations:
+        k8s.grafana.io/scrape: "true"
+        k8s.grafana.io/metrics.path: /prometheus/metrics
+        k8s.grafana.io/metrics.portNumber: {{ .Values.service.targetPort | quote }}
+      {{- end }}
+    spec:
+      automountServiceAccountToken: false
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command: ["gotenberg"]
+        args:
+          - --api-port={{ .Values.service.targetPort }}
+          - --api-timeout={{ .Values.gotenberg.apiTimeout }}
+          {{- if .Values.gotenberg.autoStart }}
+          - --chromium-auto-start=true
+          - --libreoffice-auto-start=true
+          {{- end }}
+          {{- if .Values.gotenberg.basicAuth.enabled }}
+          - --api-enable-basic-auth=true
+          {{- end }}
+          {{- with .Values.gotenberg.chromiumDenyList }}
+          - --chromium-deny-list={{ . }}
+          {{- end }}
+          {{- range .Values.gotenberg.extraArgs }}
+          - {{ . | quote }}
+          {{- end }}
+        {{- if .Values.gotenberg.basicAuth.enabled }}
+        env:
+          - name: GOTENBERG_API_BASIC_AUTH_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.gotenberg.basicAuth.existingSecret }}
+                key: {{ .Values.gotenberg.basicAuth.usernameKey }}
+          - name: GOTENBERG_API_BASIC_AUTH_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.gotenberg.basicAuth.existingSecret }}
+                key: {{ .Values.gotenberg.basicAuth.passwordKey }}
+        {{- end }}
+        ports:
+          - containerPort: {{ .Values.service.targetPort }}
+            protocol: TCP
+            name: http
+        # /health no requiere auth y refleja el estado de Chromium/LibreOffice
+        startupProbe:
+          httpGet:
+            path: /health
+            port: http
+          periodSeconds: 5
+          failureThreshold: 24
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: http
+          periodSeconds: 15
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: http
+          periodSeconds: 10
+          timeoutSeconds: 5
+        {{- with .Values.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        volumeMounts:
+          - name: tmp
+            mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir:
+            sizeLimit: {{ .Values.tmpVolume.sizeLimit }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "gotenberg.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gotenberg.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "gotenberg.selectorLabels" . | nindent 4 }}

--- a/infra/charts/gotenberg/templates/deployment.yaml
+++ b/infra/charts/gotenberg/templates/deployment.yaml
@@ -34,8 +34,10 @@ spec:
         args:
           - --api-port={{ .Values.service.targetPort }}
           - --api-timeout={{ .Values.gotenberg.apiTimeout }}
-          {{- if .Values.gotenberg.autoStart }}
+          {{- if .Values.gotenberg.autoStart.chromium }}
           - --chromium-auto-start=true
+          {{- end }}
+          {{- if .Values.gotenberg.autoStart.libreoffice }}
           - --libreoffice-auto-start=true
           {{- end }}
           {{- if .Values.gotenberg.basicAuth.enabled }}
@@ -65,12 +67,14 @@ spec:
             protocol: TCP
             name: http
         # /health no requiere auth y refleja el estado de Chromium/LibreOffice
+        # Arranque de Chromium (+LibreOffice si autoStart) con 1 CPU de límite
+        # puede pasar de 2 min en runners lentos: hasta 5 min de gracia.
         startupProbe:
           httpGet:
             path: /health
             port: http
           periodSeconds: 5
-          failureThreshold: 24
+          failureThreshold: {{ .Values.startupProbe.failureThreshold }}
         livenessProbe:
           httpGet:
             path: /health

--- a/infra/charts/gotenberg/templates/deployment.yaml
+++ b/infra/charts/gotenberg/templates/deployment.yaml
@@ -98,10 +98,17 @@ spec:
         volumeMounts:
           - name: tmp
             mountPath: /tmp
+          # Chromium escribe su crashpad/config bajo $HOME: con rootfs RO muere
+          # con "chrome_crashpad_handler: --database is required"
+          - name: home
+            mountPath: /home/gotenberg
       volumes:
         - name: tmp
           emptyDir:
             sizeLimit: {{ .Values.tmpVolume.sizeLimit }}
+        - name: home
+          emptyDir:
+            sizeLimit: {{ .Values.homeVolume.sizeLimit }}
 ---
 apiVersion: v1
 kind: Service

--- a/infra/charts/gotenberg/templates/httproute.yaml
+++ b/infra/charts/gotenberg/templates/httproute.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.route.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "gotenberg.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gotenberg.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    - name: {{ .Values.route.gateway.name }}
+      namespace: {{ .Values.route.gateway.namespace }}
+      sectionName: {{ .Values.route.gateway.sectionName }}
+  hostnames:
+    - {{ .Values.route.hostname | quote }}
+  rules:
+    - backendRefs:
+        - name: {{ include "gotenberg.fullname" . }}
+          port: {{ .Values.service.port }}
+{{- end }}

--- a/infra/charts/gotenberg/templates/networkpolicy.yaml
+++ b/infra/charts/gotenberg/templates/networkpolicy.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.networkPolicy.enabled }}
+# Referencia de NetworkPolicy para apps propias: ingress cerrado por defecto,
+# abierto solo desde el Gateway (traefik) y el scraping (monitoring).
+# ⚠️ Requiere un CNI con enforcement (flannel/minikube NO la aplican; se
+# declara igualmente: documenta la intención y se activa al migrar el CNI).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "gotenberg.fullname" . }}
+  labels:
+    {{- include "gotenberg.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "gotenberg.selectorLabels" . | nindent 6 }}
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        {{- range .Values.networkPolicy.allowFromNamespaces }}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ . }}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.service.targetPort }}
+{{- end }}

--- a/infra/charts/gotenberg/values.yaml
+++ b/infra/charts/gotenberg/values.yaml
@@ -38,6 +38,10 @@ securityContext:
   capabilities:
     drop: ["ALL"]
 
+# startupProbe: periodSeconds 5 × failureThreshold (60 → 5 min)
+startupProbe:
+  failureThreshold: 60
+
 # Tamaño máximo del emptyDir de /tmp (ficheros temporales de conversión)
 tmpVolume:
   sizeLimit: 1Gi
@@ -45,9 +49,12 @@ tmpVolume:
 gotenberg:
   # Timeout global por petición (conversiones largas → 504 en lugar de colgar)
   apiTimeout: 60s
-  # Arrancar Chromium/LibreOffice con el pod (primera conversión rápida;
-  # la readiness ya refleja que están listos)
-  autoStart: true
+  # Arrancar los motores con el pod (primera conversión rápida; la readiness
+  # refleja que están listos). LibreOffice en perezoso por defecto: arranca
+  # en la primera conversión Office y compite menos con Chromium al inicio.
+  autoStart:
+    chromium: true
+    libreoffice: false
   # Sin auth, cualquiera en internet puede usar la API (y Chromium puede
   # navegar a URLs internas del cluster). Con basicAuth.enabled el chart lee
   # GOTENBERG_API_BASIC_AUTH_USERNAME/PASSWORD del Secret indicado.

--- a/infra/charts/gotenberg/values.yaml
+++ b/infra/charts/gotenberg/values.yaml
@@ -1,0 +1,88 @@
+# Default values for gotenberg chart
+replicaCount: 1
+
+image:
+  repository: gotenberg/gotenberg
+  # Se inyecta desde versions.env (GOTENBERG_IMAGE_VERSION) vía helmfile
+  tag: ""
+  pullPolicy: IfNotPresent
+
+# Chromium + LibreOffice: una conversión puede pasar de 500Mi de pico.
+resources:
+  limits:
+    cpu: "1"
+    memory: 1536Mi
+  requests:
+    cpu: 200m
+    memory: 512Mi
+
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 3000
+
+# La imagen corre como usuario gotenberg (uid/gid 1001). Root FS de solo
+# lectura: lo único que escribe es /tmp (workdir de conversiones y perfiles de
+# Chromium/LibreOffice), montado como emptyDir.
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1001
+  runAsGroup: 1001
+  fsGroup: 1001
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop: ["ALL"]
+
+# Tamaño máximo del emptyDir de /tmp (ficheros temporales de conversión)
+tmpVolume:
+  sizeLimit: 1Gi
+
+gotenberg:
+  # Timeout global por petición (conversiones largas → 504 en lugar de colgar)
+  apiTimeout: 60s
+  # Arrancar Chromium/LibreOffice con el pod (primera conversión rápida;
+  # la readiness ya refleja que están listos)
+  autoStart: true
+  # Sin auth, cualquiera en internet puede usar la API (y Chromium puede
+  # navegar a URLs internas del cluster). Con basicAuth.enabled el chart lee
+  # GOTENBERG_API_BASIC_AUTH_USERNAME/PASSWORD del Secret indicado.
+  basicAuth:
+    enabled: true
+    existingSecret: gotenberg-basic-auth
+    usernameKey: username
+    passwordKey: password
+  # Anti-SSRF: además del default (file:// fuera de /tmp), bloquea loopback,
+  # rangos privados/link-local, metadata y nombres de servicio del cluster.
+  # Regex Go (RE2). Se aplica a la navegación de Chromium (URL → PDF).
+  chromiumDenyList: >-
+    ^file:///[^tmp].*|^https?://(localhost|127\.[0-9.]+|0\.0\.0\.0|\[::1\]|10\.[0-9.]+|172\.(1[6-9]|2[0-9]|3[01])\.[0-9.]+|192\.168\.[0-9.]+|169\.254\.[0-9.]+|[^/]*\.(svc|cluster\.local|internal|local))(:[0-9]+)?(/.*)?$
+  # Flags adicionales (p. ej. --libreoffice-disable-routes)
+  extraArgs: []
+
+# Anotaciones k8s.grafana.io/scrape para Alloy. Desactivado por defecto:
+# con basicAuth.enabled, /prometheus/metrics TAMBIÉN exige credenciales
+# (verificado 8.36: 401) y el scrape anónimo fallaría. Activar solo tras
+# configurar basic_auth en el scrape de Alloy (docs/observability.md).
+metrics:
+  enabled: false
+
+# NetworkPolicy de referencia: ingress solo desde el Gateway y monitoring.
+# Sin enforcement en flannel/minikube (declarativa); ver docs/architecture.md.
+networkPolicy:
+  enabled: true
+  allowFromNamespaces: [traefik, monitoring]
+
+# Exposición vía Gateway API (HTTPRoute). El TLS se termina en el listener
+# del Gateway, así que aquí solo se declara el hostname.
+route:
+  enabled: true
+  hostname: gotenberg.127.0.0.1.nip.io
+  gateway:
+    name: traefik-gateway
+    namespace: traefik
+    sectionName: websecure

--- a/infra/charts/gotenberg/values.yaml
+++ b/infra/charts/gotenberg/values.yaml
@@ -22,8 +22,9 @@ service:
   targetPort: 3000
 
 # La imagen corre como usuario gotenberg (uid/gid 1001). Root FS de solo
-# lectura: lo único que escribe es /tmp (workdir de conversiones y perfiles de
-# Chromium/LibreOffice), montado como emptyDir.
+# lectura: solo escribe en /tmp (workdir de conversiones y perfiles de
+# Chromium/LibreOffice) y en $HOME=/home/gotenberg (crashpad/config de
+# Chromium), ambos emptyDir.
 podSecurityContext:
   runAsNonRoot: true
   runAsUser: 1001
@@ -45,6 +46,9 @@ startupProbe:
 # Tamaño máximo del emptyDir de /tmp (ficheros temporales de conversión)
 tmpVolume:
   sizeLimit: 1Gi
+# emptyDir de /home/gotenberg (crashpad/config de Chromium)
+homeVolume:
+  sizeLimit: 256Mi
 
 gotenberg:
   # Timeout global por petición (conversiones largas → 504 en lugar de colgar)

--- a/infra/envs/minikube/gotenberg-values.yaml
+++ b/infra/envs/minikube/gotenberg-values.yaml
@@ -1,0 +1,3 @@
+# infra/envs/minikube/gotenberg-values.yaml
+route:
+  hostname: gotenberg.127.0.0.1.nip.io

--- a/infra/envs/netcup/gotenberg-values.yaml
+++ b/infra/envs/netcup/gotenberg-values.yaml
@@ -1,0 +1,4 @@
+# infra/envs/netcup/gotenberg-values.yaml
+# gotenberg.albertperez.dev vía Gateway API (TLS del wildcard en el Gateway).
+route:
+  hostname: gotenberg.albertperez.dev

--- a/scripts/generate-credentials.sh
+++ b/scripts/generate-credentials.sh
@@ -19,6 +19,8 @@ set -euo pipefail
 #               namespace velero; requiere R2_ACCESS_KEY_ID/R2_SECRET_ACCESS_KEY)
 #   langfuse    secretos del stack Langfuse (Secret langfuse-secrets, namespace
 #               langfuse; todas las variables opcionales → aleatorias)
+#   gotenberg   basic auth de la API de Gotenberg (Secret gotenberg-basic-auth,
+#               namespace gotenberg; GOTENBERG_USER/GOTENBERG_PASSWORD opcionales)
 #   all         todos salvo grafana-cloud y velero (cuenta externa) y langfuse
 #               (regenerar su salt/encryption-key ROMPE los datos cifrados:
 #               sellarlo UNA vez, explícitamente)
@@ -32,6 +34,7 @@ set -euo pipefail
 #   cloudflare     CLOUDFLARE_API_TOKEN (obligatoria)
 #   grafana-cloud  GRAFANA_CLOUD_PROM_USER / _LOKI_USER / _TOKEN
 #   velero         R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY
+#   gotenberg      GOTENBERG_USER (def. gotenberg) / GOTENBERG_PASSWORD
 # Sin la variable correspondiente se genera aleatoria (salvo tokens externos).
 
 # Source versions from centralized file
@@ -82,7 +85,7 @@ while [[ $# -gt 0 ]]; do
             shift 2
             ;;
         --help|-h)
-            echo "Usage: $0 [--component basic-auth|grafana|cloudflare|argocd-redis|grafana-cloud|velero|langfuse|all] [--namespace NS] [--users \"u1,u2\"] [--secret-name NAME]"
+            echo "Usage: $0 [--component basic-auth|grafana|cloudflare|argocd-redis|grafana-cloud|velero|langfuse|gotenberg|all] [--namespace NS] [--users \"u1,u2\"] [--secret-name NAME]"
             echo ""
             echo "Environment variables (.env — ver .env.example):"
             echo "  TRAEFIK_LOGIN, TRAEFIK_PASSWORD      basic-auth (login del dashboard)"
@@ -92,6 +95,7 @@ while [[ $# -gt 0 ]]; do
             echo "  R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY      velero"
             echo "  LANGFUSE_SALT/_ENCRYPTION_KEY/_NEXTAUTH_SECRET/_POSTGRES_PASSWORD/"
             echo "  _CLICKHOUSE_PASSWORD/_REDIS_PASSWORD/_S3_ROOT_PASSWORD   langfuse (opcionales)"
+            echo "  GOTENBERG_USER, GOTENBERG_PASSWORD   gotenberg (opcionales)"
             exit 0
             ;;
         *)
@@ -361,6 +365,37 @@ EOF
     echo "    conservarlas fuera, defínelas en .env ANTES de sellar)"
 }
 
+# --- gotenberg (basic auth nativo de la API; env GOTENBERG_API_BASIC_AUTH_*) --
+generate_gotenberg() {
+    echo "🔐 [gotenberg] Generating Gotenberg API basic auth secret (ns=gotenberg)..."
+
+    local user="${GOTENBERG_USER:-gotenberg}"
+    local password="${GOTENBERG_PASSWORD:-}"
+    if [ -z "$password" ]; then
+        # hex: sin caracteres raros para pegarla en URLs/curl -u
+        password=$(openssl rand -hex 24)
+    fi
+    echo "🔑 gotenberg/$user: $password"
+
+    local secret_file="$TMP_DIR/gotenberg-basic-auth-secret.yaml"
+    cat > "$secret_file" << EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gotenberg-basic-auth
+  namespace: gotenberg
+  labels:
+    app.kubernetes.io/managed-by: kubeseal
+    app.kubernetes.io/component: gotenberg
+type: Opaque
+stringData:
+  username: ${user}
+  password: ${password}
+EOF
+
+    seal_secret_file "$secret_file" "${SECRETS_DIR}/gotenberg-basic-auth-sealed.yaml"
+}
+
 # --- cloudflare (token DNS-01 para cert-manager) ----------------------------
 generate_cloudflare() {
     echo "🔐 [cloudflare] Generating Cloudflare API token secret (ns=cert-manager)..."
@@ -425,17 +460,21 @@ main() {
         langfuse)
             generate_langfuse
             ;;
+        gotenberg)
+            generate_gotenberg
+            ;;
         all)
             generate_basic_auth
             generate_grafana
             generate_cloudflare
             generate_argocd_redis
+            generate_gotenberg
             # grafana-cloud y velero NO van en 'all': requieren cuenta externa.
             # langfuse tampoco: regenerar su salt/encryption-key rompe los
             # datos cifrados existentes — se sella UNA vez, explícitamente.
             ;;
         *)
-            echo "❌ Componente desconocido: $COMPONENT (basic-auth|grafana|cloudflare|argocd-redis|grafana-cloud|velero|langfuse|all)"
+            echo "❌ Componente desconocido: $COMPONENT (basic-auth|grafana|cloudflare|argocd-redis|grafana-cloud|velero|langfuse|gotenberg|all)"
             exit 1
             ;;
     esac

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -94,7 +94,7 @@ test_readiness() {
 # Test 3 – Comprobación de *namespaces* críticos
 test_namespaces() {
   echo "📁 Test 3: Verifying critical namespaces..."
-  local critical_namespaces=(traefik hello admin cert-manager argocd) missing=()
+  local critical_namespaces=(traefik hello admin cert-manager argocd gotenberg) missing=()
   for ns in "${critical_namespaces[@]}"; do
     if kubectl get namespace "$ns" >/dev/null 2>&1; then
       log_debug "Namespace $ns exists"
@@ -114,7 +114,7 @@ test_namespaces() {
 # Test 4 – Servicios críticos
 test_critical_services() {
   echo "🔧 Test 4: Verifying critical services..."
-  local services=( "traefik:traefik" "hello:hello" )
+  local services=( "traefik:traefik" "hello:hello" "gotenberg:gotenberg" )
   for pair in "${services[@]}"; do
     local svc="${pair%:*}" ns="${pair#*:}"
     if kubectl get svc "$svc" -n "$ns" >/dev/null 2>&1; then
@@ -320,6 +320,55 @@ test_catchall_redirect() {
   return 0
 }
 
+# Test 11 – Gotenberg: /health abierto, API con basic auth, conversión real
+test_gotenberg() {
+  echo "📄 Test 11: Testing Gotenberg (health, auth, HTML→PDF)..."
+
+  local host_ip="127.0.0.1" host="gotenberg.127.0.0.1.nip.io"
+  local base="https://$host:8443" code
+
+  for i in {1..3}; do
+    code=$(curl -k -s -o /dev/null -w "%{http_code}" --resolve "$host:8443:$host_ip" \
+           "$base/health" --max-time 20 || echo 000)
+    [ "$code" = 200 ] && break
+    log_warn "Retry $i: Gotenberg /health returned $code, sleeping 10s..."; sleep 10
+  done
+  [ "$code" = 200 ] || { log_error "Gotenberg /health not OK ($code)"; return 1; }
+  log_debug "Gotenberg /health is up"
+
+  # Sin credenciales la API debe rechazar (401)
+  code=$(curl -k -s -o /dev/null -w "%{http_code}" --resolve "$host:8443:$host_ip" \
+         -X POST "$base/forms/chromium/convert/html" --max-time 20 || echo 000)
+  if [ "$code" = 401 ]; then
+    log_debug "Gotenberg API requires auth (401 without credentials)"
+  else
+    log_error "Gotenberg API answered $code without credentials (expected 401)"
+    return 1
+  fi
+
+  # Con credenciales: conversión HTML→PDF real (Chromium)
+  if [ -z "${GOTENBERG_USER:-}" ] || [ -z "${GOTENBERG_PASSWORD:-}" ]; then
+    log_warn "GOTENBERG_USER/GOTENBERG_PASSWORD not set, skipping authenticated conversion"
+    return 0
+  fi
+  local html_file pdf_file
+  html_file=$(mktemp -t index.XXXXXX.html); pdf_file=$(mktemp)
+  echo '<html><body><h1>smoke</h1></body></html>' > "$html_file"
+  code=$(curl -k -s -o "$pdf_file" -w "%{http_code}" --resolve "$host:8443:$host_ip" \
+         -u "$GOTENBERG_USER:$GOTENBERG_PASSWORD" --max-time 90 \
+         -F "files=@$html_file;filename=index.html" \
+         "$base/forms/chromium/convert/html" || echo 000)
+  local magic; magic=$(head -c 4 "$pdf_file" 2>/dev/null || true)
+  rm -f "$html_file" "$pdf_file"
+  if [ "$code" = 200 ] && [ "$magic" = "%PDF" ]; then
+    log_info "Gotenberg HTML→PDF conversion works"
+    return 0
+  fi
+  log_error "Gotenberg conversion failed (http $code, magic '$magic')"
+  kubectl logs -n gotenberg -l app.kubernetes.io/name=gotenberg --tail=50 || true
+  return 1
+}
+
 # ---------- Resumen de estado ----------
 show_cluster_status() {
   echo -e "\n📊 Cluster Status Summary:"
@@ -336,6 +385,7 @@ show_cluster_status() {
   echo -e "\n🌐 Access URLs (minikube):"
   echo "  Traefik Dashboard: https://traefik.127.0.0.1.nip.io/dashboard/"
   echo "  Hello App:        http://hello.127.0.0.1.nip.io"
+  echo "  Gotenberg API:    https://gotenberg.127.0.0.1.nip.io (basic auth)"
 }
 
 # ---------- Ejecución principal ----------
@@ -356,6 +406,7 @@ main() {
     test_sealed_secrets
     test_resource_utilization
     test_catchall_redirect
+    test_gotenberg
   )
 
   # Permite continuar para mostrar el resumen aunque falle una prueba

--- a/versions.env
+++ b/versions.env
@@ -61,6 +61,10 @@ export GATEWAY_API_VERSION="v1.5.1"
 
 # Application Versions (chart local, se versiona a mano)
 export HELLO_CHART_VERSION="0.3.0"
+export GOTENBERG_CHART_VERSION="0.1.0"
+# Imagen de Gotenberg (chart local: el tag se pinea aquí, no en el chart)
+# renovate: datasource=docker depName=gotenberg/gotenberg
+export GOTENBERG_IMAGE_VERSION="8.36.0"
 
 # Feature flags de apps solo-prod: en "false" la release no se instala aunque
 # el entorno sea netcup. Poner a "true" cuando exista la configuración externa:
@@ -77,6 +81,10 @@ export PROMETHEUS_ENABLED="false"
 #   contra prod: ./scripts/generate-credentials.sh --component langfuse con
 #   contexto kubectl netcup + commit + kubectl apply del sealed.
 export LANGFUSE_ENABLED="true"
+# - GOTENBERG_ENABLED solo afecta a netcup (en minikube/CI siempre se instala,
+#   con basic auth generado al vuelo). Requiere gotenberg-basic-auth sellado
+#   contra prod: ./scripts/generate-credentials.sh --component gotenberg.
+export GOTENBERG_ENABLED="true"
 
 # GitHub Action Versions
 export CHECKOUT_ACTION_VERSION="v4"


### PR DESCRIPTION
## Gotenberg en gotenberg.albertperez.dev

API HTTP para convertir HTML/Markdown/URL/Office a PDF (Chromium + LibreOffice).

### Qué incluye
- Chart local `infra/charts/gotenberg` (imagen oficial `gotenberg/gotenberg:8.36.0`, pineada en `versions.env` con anotación renovate).
- Pod bajo PSS **restricted**: uid 1001, rootfs RO (emptyDir en `/tmp` y `/home/gotenberg`), sin SA token, sin capabilities, seccomp RuntimeDefault.
- **Basic auth nativo** (`--api-enable-basic-auth`) desde el SealedSecret `gotenberg-basic-auth` (nuevo componente en `generate-credentials.sh`; sellado contra netcup).
- **Deny-list de Chromium** anti-SSRF (loopback, privadas, link-local, `*.svc`/`cluster.local`).
- HTTPRoute al Gateway, NetworkPolicy, ResourceQuota/LimitRange en `policies`, namespace bootstrap.
- dev-ci: secreto al vuelo, pre-pull de imagen, wait + debug; smoke test 11 (health, 401 sin auth, conversión HTML→PDF real).
- `GOTENBERG_ENABLED` gatea netcup como langfuse.

### Validación
- Dev CI verde: https://github.com/al6ert/albert-cluster/actions/runs/32361150466
- Local: 11/11 smoke tests; SSRF a `10.96.0.1` y `kubernetes.default.svc` → 403; credenciales erróneas → 401; URL pública → PDF válido.

### ⚠️ Paso manual en prod ANTES del merge
ArgoCD no gestiona bootstrap; aplicar namespace (label PSS) + SealedSecret:
```bash
kubectl --context netcup apply \
  -f infra/bootstrap/namespaces/gotenberg.yaml \
  -f infra/bootstrap/secrets/gotenberg-basic-auth-sealed.yaml
```
Sin el Secret el pod queda en `CreateContainerConfigError` y el `argocd app wait --health` del job de promoción fallará (selfHeal lo recupera al aplicarlo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
