### PR TITLE
fix(ci): alerta de GitGuardian y carrera de propiedad Helm/ArgoCD en dev-ci

### DIFF
--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -1,0 +1,22 @@
+# Configuración de ggshield (escaneos locales / pre-commit / CI).
+# Nota: la app de GitGuardian en GitHub NO lee este fichero; las alertas del
+# dashboard se cierran allí (falso positivo) o con una exclusión custom.
+version: 2
+
+secret:
+  ignored-matches:
+    # Contraseña dummy del basic auth de Gotenberg en dev-ci (commit 4a1d2f9).
+    # Era efímera: se sellaba contra el sealed-secrets del minikube del runner y
+    # moría con el job. Ya no existe en HEAD (se genera con `openssl rand`),
+    # pero sigue en el historial y dispara en escaneos completos del repo.
+    - name: gotenberg dev-ci basic auth (dummy, histórico)
+      match: 23602d0a875acdbe85882a24edcf08ce33693aa637a8e7d37f57c2e6eb0a1644
+
+    # Contraseña dummy de Grafana en dev-ci (mismo caso: cluster efímero de CI).
+    - name: grafana admin dev-ci (dummy)
+      match: 8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918
+
+  ignored-paths:
+    # Blobs cifrados de SealedSecrets: no son secretos en claro, pero su entropía
+    # dispara detectores genéricos.
+    - infra/bootstrap/secrets/**

--- a/.github/workflows/dev-ci.yaml
+++ b/.github/workflows/dev-ci.yaml
@@ -215,10 +215,6 @@ jobs:
           }
           echo "::endgroup::"
 
-          echo "::group::Phase 9: Apply ArgoCD ApplicationSet"
-          kubectl apply -f appset-minikube.yaml
-          echo "::endgroup::"
-
       - name: Validate Manifests (minikube)
         uses: ./.github/actions/validate-manifests
         with:
@@ -274,6 +270,20 @@ jobs:
             exit 1
           }
           echo "✅ Certificate wildcard-minikube-tls ready"
+
+      # Se aplica DESPUÉS de helmfile sync a propósito. El ApplicationSet
+      # descubre infra/apps/*/app.yaml en la rama dev remota y ArgoCD (wave 2
+      # del propio sync) renderiza los mismos charts vía el CMP de helmfile,
+      # aplicándolos con semántica kubectl: los objetos nacen sin anotaciones
+      # meta.helm.sh/*. Si Argo se adelanta a helmfile en la wave 3, el
+      # `helm install` de esa app aborta con "invalid ownership metadata"
+      # (visto 2026-08-21 con gotenberg, la última release de la wave 3 y por
+      # tanto la que más ventana le da a Argo). Aplicándolo aquí, helmfile ya
+      # ha sellado la propiedad Helm y Argo adopta los objetos sin conflicto.
+      - name: Apply ArgoCD ApplicationSet
+        run: |
+          cd infra/bootstrap
+          kubectl apply -f appset-minikube.yaml
 
       - name: Debug Gotenberg if deployment fails
         if: failure()

--- a/.github/workflows/dev-ci.yaml
+++ b/.github/workflows/dev-ci.yaml
@@ -151,11 +151,19 @@ jobs:
           SECRETS_DIR="$LANGFUSE_SECRETS_DIR" ../../scripts/generate-credentials.sh --component langfuse
           kubectl apply -f "$LANGFUSE_SECRETS_DIR/langfuse-secrets-sealed.yaml"
 
-          # Gotenberg: basic auth de la API (usuario/contraseña fijos en CI para
-          # que el smoke test se autentique); dir temporal para no pisar el
-          # sellado de prod del repo
+          # Gotenberg: basic auth de la API. La credencial se genera al vuelo y
+          # se pasa al smoke test vía $GITHUB_ENV (nada de literales en el repo);
+          # dir temporal para no pisar el sellado de prod del repo
           GOTENBERG_SECRETS_DIR=$(mktemp -d)
-          SECRETS_DIR="$GOTENBERG_SECRETS_DIR" GOTENBERG_USER=ci GOTENBERG_PASSWORD=ci-gotenberg \
+          GOTENBERG_CI_USER=ci
+          GOTENBERG_CI_SECRET=$(openssl rand -hex 16)
+          echo "::add-mask::$GOTENBERG_CI_SECRET"
+          {
+            echo "GOTENBERG_USER=$GOTENBERG_CI_USER"
+            echo "GOTENBERG_PASSWORD=$GOTENBERG_CI_SECRET"
+          } >> "$GITHUB_ENV"
+          SECRETS_DIR="$GOTENBERG_SECRETS_DIR" \
+          GOTENBERG_USER="$GOTENBERG_CI_USER" GOTENBERG_PASSWORD="$GOTENBERG_CI_SECRET" \
             ../../scripts/generate-credentials.sh --component gotenberg
           kubectl apply -f "$GOTENBERG_SECRETS_DIR/gotenberg-basic-auth-sealed.yaml"
 
@@ -351,7 +359,9 @@ jobs:
       - name: Enhanced smoke tests
         run: |
           chmod +x tests/smoke.sh
-          WAIT_TIMEOUT=300s GOTENBERG_USER=ci GOTENBERG_PASSWORD=ci-gotenberg ./tests/smoke.sh
+          # GOTENBERG_USER/GOTENBERG_PASSWORD llegan del step de sealed secrets
+          # (exportados a $GITHUB_ENV)
+          WAIT_TIMEOUT=300s ./tests/smoke.sh
 
       - name: Cleanup Minikube
         if: always()

--- a/deploy-local.sh
+++ b/deploy-local.sh
@@ -189,15 +189,6 @@ EOF
 
     wait_for_sealed_secrets
 
-    echo "::group::Phase 3: ArgoCD Applications (optional for local)"
-    if [[ "${DEPLOY_ARGOCD_APPS:-true}" == "true" ]]; then
-        kubectl apply -f appset-minikube.yaml --validate=false
-        echo "✅ ArgoCD ApplicationSet applied"
-    else
-        echo "⚠️ Skipping ArgoCD applications (DEPLOY_ARGOCD_APPS=false)"
-    fi
-    echo "::endgroup::"
-
     echo "✅ Bootstrap phase completed"
 }
 
@@ -250,6 +241,21 @@ deploy_applications() {
         echo "⚠️ Some deployments not ready within timeout, checking individual status..."
         kubectl get deployments -A | grep -E "(0/|False)"
     }
+
+    # ArgoCD DESPUÉS del sync a propósito: el ApplicationSet descubre
+    # infra/apps/*/app.yaml en la rama dev remota y ArgoCD renderiza los mismos
+    # charts vía el CMP de helmfile, aplicándolos con semántica kubectl (sin
+    # anotaciones meta.helm.sh/*). Si Argo se adelanta, el helm install de esa
+    # app aborta con "invalid ownership metadata" (visto 2026-08-21 en dev-ci
+    # con gotenberg). Aquí helmfile ya ha sellado la propiedad y Argo adopta.
+    echo "::group::ArgoCD ApplicationSet (optional for local)"
+    if [[ "${DEPLOY_ARGOCD_APPS:-true}" == "true" ]]; then
+        kubectl apply -f "${SCRIPT_DIR}/infra/bootstrap/appset-minikube.yaml" --validate=false
+        echo "✅ ArgoCD ApplicationSet applied"
+    else
+        echo "⚠️ Skipping ArgoCD applications (DEPLOY_ARGOCD_APPS=false)"
+    fi
+    echo "::endgroup::"
 
     echo "✅ Application deployment completed"
 }


### PR DESCRIPTION
Dos arreglos de CI/tooling. **No toca ningún manifiesto**: el diff son
`.gitguardian.yaml`, `.github/workflows/dev-ci.yaml` y `deploy-local.sh`, así que
la promoción a prod no cambia nada de lo que ArgoCD despliega en Netcup.

## 5c91d6e — literal de credencial fuera de dev-ci

GitGuardian marcó `GOTENBERG_PASSWORD=ci-gotenberg` (commit 4a1d2f9) como
"Generic Password". Era efímera —se sellaba contra el sealed-secrets del minikube
del runner y moría con el job—, así que no había nada que rotar, pero el literal
sobraba. Ahora se genera con `openssl rand -hex 16`, se enmascara con
`::add-mask::` y viaja al smoke test por `$GITHUB_ENV`.

Se añade `.gitguardian.yaml` con los hashes del literal histórico y del
`GRAFANA_ADMIN_PASSWORD=admin` de CI. Solo lo lee ggshield (aún no instalado), no
la app de GitHub.

## f7b1256 — carrera de propiedad Helm/ArgoCD

`dev-ci` falló en `Deploy applications to Minikube` con:

```
Error: Unable to continue with install: NetworkPolicy "gotenberg" in namespace
"gotenberg" exists and cannot be imported into the current release:
missing key "meta.helm.sh/release-name"
```

En minikube conviven dos sistemas desplegando los mismos charts. El appset se
aplicaba en el bootstrap; ArgoCD arranca en la wave 2 del propio `helmfile sync`,
descubre `infra/apps/*/app.yaml` y renderiza con el CMP, aplicando con semántica
kubectl (sin anotaciones `meta.helm.sh/*`). Cuando helmfile llega a la wave 3
encuentra el objeto sin dueño y aborta. El `missing key` —en vez de
`must equal X: current value is Y`— es la firma de creado-fuera-de-Helm.

Cronología medida en el run 32467493694: argocd listo 09:24:53 → ArgoCD crea el
Deployment de gotenberg 09:25:49 → helmfile no llega hasta 09:26:37, porque
langfuse (la entrada anterior de la wave 3, que helmfile instala en serie) tardó
77s. 48s de ventaja para Argo. Por eso 57da0de pasó y 5c91d6e no: puro timing.
`hello`, `prometheus` y `policies` tenían la misma carrera latente.

Fix: el appset se aplica **después** del sync, en dev-ci (step propio) y en
deploy-local.sh (de `apply_bootstrap` a `deploy_applications`, que además es el
orden que ya documentaba `docs/deployment.md:36-42`). `bootstrap-prod.sh` no se
toca: solo helmfilea los 4 core y crea el appset al final.

## Verificación

Run [32470238206](https://github.com/al6ert/albert-cluster/actions/runs/32470238206)
sobre `f7b1256`: **success, 11/11 smoke tests**. Langfuse volvió a tardar 1m9s y
gotenberg instaló detrás en 6s sin obstáculo; el test 11 hizo la conversión
HTML→PDF autenticada de verdad (no cayó en la rama de skip), confirmando que la
credencial generada al vuelo llega por `$GITHUB_ENV`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)